### PR TITLE
Spelling fix: Visaul -> Visual

### DIFF
--- a/static/_locales/en/messages.json
+++ b/static/_locales/en/messages.json
@@ -6,7 +6,7 @@
     "message": "Simple speed dial bookmarks page, including search, add, edit, delete and dragging bookmarks."
   },
   "default_title": {
-    "message": "Visaul bookmarks"
+    "message": "Visual bookmarks"
   },
   "dark_theme": {
     "message": "Dark theme"


### PR DESCRIPTION
Visaul is misspelled in the Chrome nav bar 😜. 

Proof:
![screen shot 2019-02-20 at 3 36 32 pm](https://user-images.githubusercontent.com/4150517/53126274-5bb28900-3525-11e9-8bce-e8ab3ad286d1.png)
